### PR TITLE
use "#!/usr/bin/env bash" instead of "!#/bin/bash"

### DIFF
--- a/meta/create_bootstrap.sh
+++ b/meta/create_bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Checkpoint the current state of the system by creating a new bootstrap
 # YASM file for MacOS and Linux to ./bootstrap/

--- a/meta/test.sh
+++ b/meta/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for f in $(ls tests | grep -v "common")
 do 

--- a/tests/arrays.sh
+++ b/tests/arrays.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test Builtin functions
 

--- a/tests/builtins.sh
+++ b/tests/builtins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test Builtin functions
 

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_exit_status() {
     ./build/cupcc -c "$1" -o ./build/test -s

--- a/tests/conditions.sh
+++ b/tests/conditions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tests/common.sh
 

--- a/tests/core.sh
+++ b/tests/core.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tests/common.sh
 

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test compound scopes
 

--- a/tests/loops.sh
+++ b/tests/loops.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tests/common.sh
 

--- a/tests/types.sh
+++ b/tests/types.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tests/common.sh
 

--- a/tests/variables.sh
+++ b/tests/variables.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . tests/common.sh
 


### PR DESCRIPTION
The "#!/usr/bin/env bash" shebang header is more flexible and works with more distributions.  Using /usr/bin/env means bash will be selected based on PATH.  This means different versions of bash can be used for each shell environment which is difficult when using a hardcoded globally share path like /bin/bash.  This also makes it work on more distributions which don't use global shared paths like NixOS.